### PR TITLE
:bug: Fix empty section bug

### DIFF
--- a/src/core/__snapshots__/issue-body.spec.js.snap
+++ b/src/core/__snapshots__/issue-body.spec.js.snap
@@ -35,3 +35,20 @@ Environment markdown
 - **awesome info**: it works
 "
 `;
+
+exports[`makeIssueBodyFromReport should handle empty sections 1`] = `
+"## Stacktrace
+
+\`\`\`
+Stack
+\`\`\`
+
+## Environment
+
+Environment markdown
+
+## Second section
+
+- **awesome info**: it works
+"
+`;

--- a/src/core/issue-body.js
+++ b/src/core/issue-body.js
@@ -3,7 +3,7 @@ const Handlebars = require('handlebars')
 
 module.exports = function makeIssueBodyFromReport({
   errorReport,
-  sections,
+  sections = [],
   formatReport
 }) {
   if (formatReport) return formatReport(errorReport)
@@ -32,6 +32,14 @@ module.exports = function makeIssueBodyFromReport({
   return compiler({
     error: errorReport.error,
     environment: errorReport.environment,
-    sections
+    sections: sections.filter(section => {
+      const hasContent = Boolean(section.content)
+      if (!hasContent) {
+        console.warn(
+          `⚠️  The section "${section.title}" is ${section.content}.`
+        )
+      }
+      return hasContent
+    })
   })
 }

--- a/src/core/issue-body.spec.js
+++ b/src/core/issue-body.spec.js
@@ -73,4 +73,35 @@ describe('makeIssueBodyFromReport', () => {
     expect(formatReport).toHaveBeenCalledWith(errorReport)
     expect(result).toBe(customFormat)
   })
+
+  it('should handle empty sections', () => {
+    const errorReport = {
+      error: {
+        title: 'Stacktrace',
+        stack: 'Stack'
+      },
+      environment: {
+        title: 'Environment',
+        markdown: 'Environment markdown'
+      }
+    }
+
+    const result = makeIssueBodyFromReport({
+      errorReport,
+      sections: [
+        {
+          title: 'Custom section',
+          content: null
+        },
+        {
+          title: 'Second section',
+          content: {
+            'awesome info': 'it works'
+          }
+        }
+      ]
+    })
+
+    expect(result).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Fix #5 

When a section content is empty. `Object.keys` function throws an error. I make it 'fail safe'. It still throws a warning so user knows there is an empty section.